### PR TITLE
Prevent mutation of paths array in cacheHttpClient

### DIFF
--- a/packages/warp-cache/src/internal/cacheHttpClient.ts
+++ b/packages/warp-cache/src/internal/cacheHttpClient.ts
@@ -113,7 +113,7 @@ export function getCacheVersion(
   enableCrossOsArchive = false,
   enableCrossArchArchive = false
 ): string {
-  // be carefult not to mutate the path while creating a hash
+  // be careful not to mutate the path while creating a hash
   const components = paths.slice()
 
   // Add compression method to cache version to restore

--- a/packages/warp-cache/src/internal/cacheHttpClient.ts
+++ b/packages/warp-cache/src/internal/cacheHttpClient.ts
@@ -113,7 +113,8 @@ export function getCacheVersion(
   enableCrossOsArchive = false,
   enableCrossArchArchive = false
 ): string {
-  const components = paths
+  // be carefult not to mutate the path while creating a hash
+  const components = paths.slice()
 
   // Add compression method to cache version to restore
   // compressed cache as per compression method


### PR DESCRIPTION
This PR adjust the getCacheVersion in the internal warp-cache by preventing mutation of the paths array by using slice() to create a copy.

I discovered this bug while adding warpbuild support to https://github.com/nix-community/cache-nix-action/pull/321

This is important because restoreCacheV2 passes the paths array by reference, and the current impl is modifying that paths array, breaking cache paths on disk, breaking caching altogether when called from other SDKs