### PR TITLE
chore: remove leaked runner token from src/test.ts

### DIFF
--- a/packages/warp-cache/src/test.ts
+++ b/packages/warp-cache/src/test.ts
@@ -9,8 +9,6 @@ process.env['WARPBUILD_CACHE_URL'] = 'http://localhost:8000'
 process.env['RUNNER_TEMP'] = '/Users/prajjwal/Repos/warpbuild/playground/tmp_fs'
 process.env['NODE_DEBUG'] = 'http'
 process.env['RUNNER_DEBUG'] = '1'
-process.env['WARPBUILD_RUNNER_VERIFICATION_TOKEN'] =
-  'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhYyI6Ilt7XCJTY29wZVwiOlwicmVmcy9oZWFkcy9tYWluXCIsXCJQZXJtaXNzaW9uXCI6M31dIiwiY29ubmVjdGlvbklkIjoiMmVkYTNiMjYtYzY5OC00YjQ5LWFjMWUtYjdhNDIyOTEyM2FiIiwiZXhwIjoxNzI5NTAwNzU5LCJuYmYiOjE3MjkyNDE1NTksInJ1bm5lcklkIjoid2FycGRldi14NjQtdzk3eng5aHIwZ2xjeW45ZiIsInN0YWNrSWQiOiJ3aHhnaWNrZHhlbTJjN3oxIiwieC13YXJwYnVpbGQtb3JnYW5pemF0aW9uLWlkIjoid2ZtbjA4MGVpZjhybml3cSJ9.YwIjh-1-u9DjauOJJNsqQ3RohbenYe1Vr00LrfZHje1bXpixBWe6I89hy0dzuko8EGq4VbtE2QNAPmankJpwxA'
 process.env['GITHUB_REPOSITORY'] = 'Warpbuilds/kitchen-sink'
 process.env['GITHUB_REF'] = 'refs/heads/main'
 


### PR DESCRIPTION
Removes a hardcoded `WARPBUILD_RUNNER_VERIFICATION_TOKEN` from `src/test.ts`. The file sits under `src/`, so it compiled into `lib/test.js` and shipped in all 7 published versions across both package names.

Token expired Oct 2024, but it decodes to a stack id, runner id and org id. Still present in git history and in the published tarballs — this only stops it being at HEAD.